### PR TITLE
Update the default TERM_PATTERN to allow for unicode word characters

### DIFF
--- a/lib/lita/handlers/karma.rb
+++ b/lib/lita/handlers/karma.rb
@@ -4,7 +4,7 @@ module Lita
   module Handlers
     # Tracks karma points for arbitrary terms.
     class Karma < Handler
-      TERM_PATTERN = /[\[\]\w\._|\{\}]{2,}/
+      TERM_PATTERN = /[\[\]\p{Word}\._|\{\}]{2,}/
 
       class << self
         attr_accessor :term_pattern

--- a/spec/lita/handlers/karma_spec.rb
+++ b/spec/lita/handlers/karma_spec.rb
@@ -1,3 +1,4 @@
+# Encoding: UTF-8
 require "spec_helper"
 
 describe Lita::Handlers::Karma, lita_handler: true do
@@ -67,6 +68,11 @@ describe Lita::Handlers::Karma, lita_handler: true do
       send_message("foo++")
       send_message("FOO++")
       expect(replies.last).to eq("foo: 2")
+    end
+
+    it "handles Unicode word characters" do
+      send_message("föö++")
+      expect(replies.last).to eq("föö: 1")
     end
   end
 


### PR DESCRIPTION
It finally bugged me enough to fix it.

I know this can be overridden, but the default should be sane.
