### PR TITLE
Upgrade modified sets even if they have no corresponding term

### DIFF
--- a/lib/lita/handlers/karma/upgrade/modified_counts.rb
+++ b/lib/lita/handlers/karma/upgrade/modified_counts.rb
@@ -12,7 +12,7 @@ module Lita::Handlers::Karma::Upgrade
 
         upgrade = config.upgrade_modified
 
-        all_terms.each { |(term, score)| upgrade_term(term, score, upgrade) }
+        all_terms.each { |term, score| upgrade_term(term, score, upgrade) }
 
         redis.incr("support:modified_counts")
       end
@@ -21,7 +21,9 @@ module Lita::Handlers::Karma::Upgrade
     private
 
     def all_terms
-      redis.zrange('terms', 0, -1, with_scores: true)
+      Hash[redis.zrange('terms', 0, -1, with_scores: true)].merge!(
+        Hash[redis.keys('modified:*').map{|x| [x.gsub(/^modified:/, ''), 0]}]
+      ) {|key, left, right| left }
     end
 
     def delete_keys(keys)

--- a/spec/lita/handlers/karma/upgrade/modified_counts_spec.rb
+++ b/spec/lita/handlers/karma/upgrade/modified_counts_spec.rb
@@ -36,5 +36,12 @@ describe Lita::Handlers::Karma::Upgrade::ModifiedCounts, lita_handler: true do
         [['bar', 0.0], ['baz', 2.0]]
       )
     end
+
+    it 'upgrades the sets for which there are no terms' do
+      subject.redis.sadd('modified:bar', %w{baz bot})
+
+      subject.modified_counts(payload)
+      expect(subject.redis.type('modified:bar')).to eq 'zset'
+    end
   end
 end


### PR DESCRIPTION
I still am not clear how this state occurred in our data (before I upgraded, I went back to a backup to confirm that), but this is one way to fix it.

Fixes #14.
