### PR TITLE
Implement Term#==, as well-behaved Ruby objects do

### DIFF
--- a/lib/lita/handlers/karma/term.rb
+++ b/lib/lita/handlers/karma/term.rb
@@ -59,6 +59,7 @@
     def eql?(other)
       term.eql?(other.term)
     end
+    alias_method :==, :eql?
 
     def hash
       term.hash


### PR DESCRIPTION
`Karma:Term` already implements the bulk of Ruby equality, the only thing missing is `#==`. This adds it.