### PR TITLE
Agalles/copy paste karma fix

### DIFF
--- a/lib/lita/handlers/karma/chat.rb
+++ b/lib/lita/handlers/karma/chat.rb
@@ -198,7 +198,7 @@ module Lita::Handlers::Karma
     # modifications, force karma tokens be followed by whitespace (in a zero-
     # width, look-ahead operator) or the end of the string.
     def token_terminator
-      %r{(?:(?=[[:space:]])$)}
+      %r{(?:(?=[[:space:]])|$)}
     end
   end
 end

--- a/lib/lita/handlers/karma/chat.rb
+++ b/lib/lita/handlers/karma/chat.rb
@@ -198,7 +198,7 @@ module Lita::Handlers::Karma
     # modifications, force karma tokens be followed by whitespace (in a zero-
     # width, look-ahead operator) or the end of the string.
     def token_terminator
-      %r{(?:(?=[[:space:]])|[.,!)"”]|$)}
+      %r{(?:(?=[[:space:]])$)}
     end
   end
 end

--- a/lib/lita/handlers/karma/chat.rb
+++ b/lib/lita/handlers/karma/chat.rb
@@ -198,7 +198,7 @@ module Lita::Handlers::Karma
     # modifications, force karma tokens be followed by whitespace (in a zero-
     # width, look-ahead operator) or the end of the string.
     def token_terminator
-      %r{(?:(?=\s)|$)}
+      %r{(?:(?=[[:space:]])|[.,!)"”]|$)}
     end
   end
 end


### PR DESCRIPTION
Multiple users can't be copied and pasted for karma because Slack interprets the space between names as a unicode space and only applies karma to a username if it's at the end of the line.

Other instances of /s are being left as-is for now

Another option is to replace all unicode spaces with ascii spaces in lita-slack, but there might have been unknown consequences and I went for the more surface-level change.

Fixes #23 